### PR TITLE
Themes: Make dialpad seperator line theme-able

### DIFF
--- a/res/layout/dialpad_view.xml
+++ b/res/layout/dialpad_view.xml
@@ -99,7 +99,7 @@
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:background="#e3e3e3" />
+        android:background="@color/dialpad_separator_line_color" />
 
     <Space
         android:layout_width="match_parent"


### PR DESCRIPTION
Using an existing value in colors is defined
(dialpad_seperator_line_color) in AOSP, but overwritten in layout
